### PR TITLE
fix typo in function call

### DIFF
--- a/lib/B/Utils.pm
+++ b/lib/B/Utils.pm
@@ -703,7 +703,7 @@ Same as above, but filtered.
 sub walkallops_filtered {
     $sub = undef;
 
-    &_walkallops_filterd;
+    &_walkallops_filtered;
 
     return _TRUE;
 }

--- a/t/regression_walkallops_filtered.t
+++ b/t/regression_walkallops_filtered.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+
+use Test::Exception tests => 1;
+
+use B::Utils qw( walkallops_filtered opgrep );
+
+lives_ok {
+    walkallops_filtered(
+        sub { opgrep( {name => "exec",
+                    next => {
+                                name    => "nextstate",
+                                sibling => { name => [qw(! exit warn die)] }
+                            }
+                    }, @_)},
+        sub {
+            warn("Statement unlikely to be reached");
+            warn("\t(Maybe you meant system() when you said exec()?)\n");
+        }
+    )
+} 'walkallops_filtered should not die when called as documented';
+


### PR DESCRIPTION
The function 'walkallops_filtered' currently doesn't work, since it calls a nonexistent function '_walkallops_filterd', which triggers AUTOLOAD to be called, which can't deal with it.

This commit fixes the typo in the function call, and adds a regression test, using an example from the documentation (with 'carp' replaced by 'warn' to keep the test slender).
