### PR TITLE
Towards making tree walk walk more fully 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,12 @@
+*~
 /.build
-/B-Utils-*
+/MYMETA.json
+/MYMETA.yml
+/Makefile
+/OP.c
+/OP.o
+/Utils.bs
+/Utils.c
+/Utils.o
+/blib
+pm_to_blib

--- a/lib/B/Utils.pm
+++ b/lib/B/Utils.pm
@@ -316,7 +316,7 @@ Like C< $op-E<gt>next >, but not quite.
 ##           for @kids;
 ##
 ##         # For each child, check it for a match.
-##      my $found;
+##         my $found;
 ##         $found = $search->($_) and return $found
 ##           for @kids;
 ##
@@ -327,7 +327,7 @@ Like C< $op-E<gt>next >, but not quite.
 ##
 ##     my $next = $target;
 ##     while ( eval { $next = $next->next } ) {
-##      my $result;
+##         my $result;
 ##         $result = $search->( $next )
 ##           and return $result;
 ##     }
@@ -644,7 +644,7 @@ sub walkoptree_filtered {
 }
 
 sub _walkoptree_filtered {
-        my ( $visited, $op, $filter, $callback, $data ) = @_;
+    my ( $visited, $op, $filter, $callback, $data ) = @_;
 
     if ( $op->isa("B::COP") ) {
         $file = $op->file;

--- a/lib/B/Utils.pm
+++ b/lib/B/Utils.pm
@@ -157,9 +157,9 @@ sub B::OP::kids {
 
     my @kids;
     if ( ref $op and $$op and $op->flags & OPf_KIDS ) {
-	for (my $kid = $op->first; $$kid; $kid = $kid->sibling) {
-	    push @kids, $kid;
-	}
+        for (my $kid = $op->first; $$kid; $kid = $kid->sibling) {
+            push @kids, $kid;
+        }
         ### Assert: $op->children == @kids
     }
     else {
@@ -316,7 +316,7 @@ Like C< $op-E<gt>next >, but not quite.
 ##           for @kids;
 ##
 ##         # For each child, check it for a match.
-## 	my $found;
+##      my $found;
 ##         $found = $search->($_) and return $found
 ##           for @kids;
 ##
@@ -327,7 +327,7 @@ Like C< $op-E<gt>next >, but not quite.
 ##
 ##     my $next = $target;
 ##     while ( eval { $next = $next->next } ) {
-## 	my $result;
+##      my $result;
 ##         $result = $search->( $next )
 ##           and return $result;
 ##     }
@@ -597,7 +597,7 @@ sub walkoptree_simple {
 sub _walkoptree_simple {
     my ( $visited, $op, $callback, $data ) = @_;
 
-	return if $visited->{$$op}++;
+        return if $visited->{$$op}++;
 
     if ( ref $op and $op->isa("B::COP") ) {
         $file = $op->file;
@@ -609,9 +609,9 @@ sub _walkoptree_simple {
         and $$op
         and $op->flags & OPf_KIDS )
     {
-	# for (my $kid = $op->first; $$kid; $kid = $kid->sibling) {
-	#     _walkoptree_simple( $visited, $kid, $callback, $data );
-	# }
+        # for (my $kid = $op->first; $$kid; $kid = $kid->sibling) {
+        #     _walkoptree_simple( $visited, $kid, $callback, $data );
+        # }
         _walkoptree_simple( $visited, $_, $callback, $data ) for $op->kids;
     }
 
@@ -638,7 +638,7 @@ sub walkoptree_filtered {
 }
 
 sub _walkoptree_filtered {
-	my ( $visited, $op, $filter, $callback, $data ) = @_;
+        my ( $visited, $op, $filter, $callback, $data ) = @_;
 
     if ( $op->isa("B::COP") ) {
         $file = $op->file;

--- a/lib/B/Utils.pm
+++ b/lib/B/Utils.pm
@@ -156,12 +156,10 @@ sub B::OP::kids {
     return unless defined wantarray;
 
     my @kids;
-    if ( class($op) eq "LISTOP" ) {
-        @kids = $op->first;
-        push @kids, $kids[-1]->sibling while $kids[-1]->can('sibling');
-        pop @kids
-            if 'NULL' eq class( $kids[-1] );
-
+    if ( ref $op and $$op and $op->flags & OPf_KIDS ) {
+	for (my $kid = $op->first; $$kid; $kid = $kid->sibling) {
+	    push @kids, $kid;
+	}
         ### Assert: $op->children == @kids
     }
     else {
@@ -611,6 +609,9 @@ sub _walkoptree_simple {
         and $$op
         and $op->flags & OPf_KIDS )
     {
+	# for (my $kid = $op->first; $$kid; $kid = $kid->sibling) {
+	#     _walkoptree_simple( $visited, $kid, $callback, $data );
+	# }
         _walkoptree_simple( $visited, $_, $callback, $data ) for $op->kids;
     }
 

--- a/lib/B/Utils.pm
+++ b/lib/B/Utils.pm
@@ -29,11 +29,11 @@ B::Utils - Helper functions for op tree manipulation
 
 =head1 VERSION
 
-0.21
+0.21_01
 
 =cut
 
-$VERSION = '0.21';
+$VERSION = '0.21_01';
 
 
 
@@ -157,9 +157,9 @@ sub B::OP::kids {
 
     my @kids;
     if ( ref $op and $$op and $op->flags & OPf_KIDS ) {
-	for (my $kid = $op->first; $$kid; $kid = $kid->sibling) {
-	    push @kids, $kid;
-	}
+        for (my $kid = $op->first; $$kid; $kid = $kid->sibling) {
+            push @kids, $kid;
+        }
         ### Assert: $op->children == @kids
     }
     else {
@@ -316,7 +316,7 @@ Like C< $op-E<gt>next >, but not quite.
 ##           for @kids;
 ##
 ##         # For each child, check it for a match.
-## 	my $found;
+##      my $found;
 ##         $found = $search->($_) and return $found
 ##           for @kids;
 ##
@@ -327,7 +327,7 @@ Like C< $op-E<gt>next >, but not quite.
 ##
 ##     my $next = $target;
 ##     while ( eval { $next = $next->next } ) {
-## 	my $result;
+##      my $result;
 ##         $result = $search->( $next )
 ##           and return $result;
 ##     }
@@ -597,7 +597,7 @@ sub walkoptree_simple {
 sub _walkoptree_simple {
     my ( $visited, $op, $callback, $data ) = @_;
 
-	return if $visited->{$$op}++;
+        return if $visited->{$$op}++;
 
     if ( ref $op and $op->isa("B::COP") ) {
         $file = $op->file;
@@ -609,9 +609,9 @@ sub _walkoptree_simple {
         and $$op
         and $op->flags & OPf_KIDS )
     {
-	# for (my $kid = $op->first; $$kid; $kid = $kid->sibling) {
-	#     _walkoptree_simple( $visited, $kid, $callback, $data );
-	# }
+        # for (my $kid = $op->first; $$kid; $kid = $kid->sibling) {
+        #     _walkoptree_simple( $visited, $kid, $callback, $data );
+        # }
         _walkoptree_simple( $visited, $_, $callback, $data ) for $op->kids;
     }
 
@@ -638,7 +638,7 @@ sub walkoptree_filtered {
 }
 
 sub _walkoptree_filtered {
-	my ( $visited, $op, $filter, $callback, $data ) = @_;
+        my ( $visited, $op, $filter, $callback, $data ) = @_;
 
     if ( $op->isa("B::COP") ) {
         $file = $op->file;

--- a/lib/B/Utils/OP.pm
+++ b/lib/B/Utils/OP.pm
@@ -8,7 +8,7 @@ use B::Utils ();
 
 our @ISA = 'Exporter';
 require Exporter;
-our $VERSION = '0.21';
+our $VERSION = '0.2101';
 our @EXPORT = qw(parent_op return_op);
 
 

--- a/t/utils/30parent.t
+++ b/t/utils/30parent.t
@@ -60,7 +60,7 @@ walkoptree_simple(
         else {
 
             ok( $parent, $op->stringify . " has a parent" );
-	    
+            
             my $correct_parent;
             for ( $parent ? $parent->kids : () ) {
                 if ( $$_ == $$op ) {
@@ -68,8 +68,8 @@ walkoptree_simple(
                     last;
                 }
             }
-	    is( $$correct_parent, $$op, 
-		$op->stringify . " has the *right* parent " . $parent);
+            is( $$correct_parent, $$op, 
+                $op->stringify . " has the *right* parent " . $parent);
         }
     }
 );

--- a/t/utils/30parent.t
+++ b/t/utils/30parent.t
@@ -1,3 +1,5 @@
+use B qw( OPf_KIDS );
+my @empty_array = ();
 test_data() for @empty_array;
 
 {
@@ -29,10 +31,21 @@ use B::Utils 'walkoptree_simple';
 # );
 # B::Concise::compile("test_data")->();
 
+# FIXME: Consider moving this into B::Utils. But consider warning about 
+# adding to B::OPS and B::Concise.
+sub has_branch($)
+{
+    my $op = shift;
+    return ref($op) and $$op and ($op->flags & OPf_KIDS);
+}
+
 # Set the # of tests to run and make a table of parents
 my $tests = 0;
 my $root  = svref_2object( \&test_data )->ROOT;
-walkoptree_simple( $root, sub { ++$tests } );
+walkoptree_simple( $root, sub { 
+    my $op = shift;
+    $tests++ if has_branch($op)} 
+    );
 plan( tests => ( $tests * 2 ) - 1 );
 
 walkoptree_simple(
@@ -47,16 +60,16 @@ walkoptree_simple(
         else {
 
             ok( $parent, $op->stringify . " has a parent" );
-
+	    
             my $correct_parent;
             for ( $parent ? $parent->kids : () ) {
                 if ( $$_ == $$op ) {
-                    $correct_parent = 1;
+                    $correct_parent = $_;
                     last;
                 }
             }
-
-            ok( $correct_parent, $op->stringify . " has the *right* parent" );
+	    is( $$correct_parent, $$op, 
+		$op->stringify . " has the *right* parent " . $parent);
         }
     }
 );

--- a/t/utils/40walk.t
+++ b/t/utils/40walk.t
@@ -1,1 +1,36 @@
-use Test::More skip_all => "No tests written yet.";
+#!perl
+use Test::More;
+use lib '../../lib';
+use lib '../../blib/arch/auto/B/Utils';
+use B qw(class);
+use B::Utils qw( all_roots walkoptree_simple);
+
+my @lines = ();
+my $callback = sub
+{
+  my $op = shift;
+  if ('COP' eq B::class($op) and  $op->file eq __FILE__) {
+    push @lines, $op->line;
+  }
+};
+
+foreach my $op (values all_roots) {
+  walkoptree_simple( $op, $callback );
+}
+is_deeply(\@lines, 
+	  [8, 15, 17, 18, 20, 27, 30, 33,
+	   # 35,
+	  ],
+	  'walkoptree_simple lines of ' . __FILE__);
+
+# For testing followoing if/else in code.
+if (@lines) {
+  ok(1);
+} else {
+  ok(0);
+}
+
+done_testing();
+__END__
+diag join(', ', @lines), "\n";
+

--- a/t/utils/40walk.t
+++ b/t/utils/40walk.t
@@ -18,14 +18,16 @@ foreach my $op (values all_roots) {
   walkoptree_simple( $op, $callback );
 }
 is_deeply(\@lines, 
-	  [8, 15, 17, 18, 20, 27, 30, 33,
-	   # 35,
-	  ],
-	  'walkoptree_simple lines of ' . __FILE__);
+          [8, 15, 17, 18, 20, 29, 
+           # 30,    # See FIXME: below
+           32, 35,
+           # 37,
+          ],
+          'walkoptree_simple lines of ' . __FILE__);
 
-# For testing followoing if/else in code.
+# For testing following if/else in code.
 if (@lines) {
-  ok(1);
+  ok(1);     # FIXME: This line isn't coming out.
 } else {
   ok(0);
 }
@@ -33,4 +35,3 @@ if (@lines) {
 done_testing();
 __END__
 diag join(', ', @lines), "\n";
-


### PR DESCRIPTION
This goes a long way towards addressing a long-standing problem in Enbugger that it doesn't  mark various  COP  lines as stoppable or breakpoint-able. This is seen for example in perl5db or Devel::Trepan when using Enbugger. 

It also can be used to greatly simplify and extend B::CodeLines. 

However there still is one omission that should be addressed. See _FIXME_ inside newly-created test `t/utils/40walk.t`
