### PR TITLE
Compensate for deleted COP nextstate instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /MYMETA.json
 /MYMETA.yml
 /Makefile
+/Makefile.old
 /OP.c
 /OP.o
 /Utils.bs

--- a/lib/B/Utils.pm
+++ b/lib/B/Utils.pm
@@ -578,9 +578,9 @@ more expected semantics.
 All the C<walk> functions set C<$B::Utils::file>, C<$B::Utils::line>,
 and C<$B::Utils::sub> to the appropriate values of file, line number,
 and sub name in the program being examined. They also set
-C<B::Utils::trace_removed> for a line number whose controling COP was
-optimized away. Such lines won't normally be breakpoint-able in a
-debugger without special work. 
+C<$B::Utils::trace_removed> when the nextstate COPs that contained
+that line was optimized away. Such lines won't normally be
+step-able or breakpoint-able in a debugger without special work.
 
 =cut
 
@@ -606,7 +606,7 @@ sub _walkoptree_simple {
         $file = $op->file;
         $line = $op->line;
         $trace_removed = _FALSE;
-    } elsif ( $op->oldname eq 'nextstate' ) {
+    } elsif ( !$op->isa('B::NULL') and $op->oldname eq 'nextstate' ) {
         # COP nextstate has been optimized away.  However by turning
         # this back into a COP we can retrieve the file and line
         # values.

--- a/t/utils/40walk.t
+++ b/t/utils/40walk.t
@@ -18,16 +18,14 @@ foreach my $op (values all_roots) {
   walkoptree_simple( $op, $callback );
 }
 is_deeply(\@lines, 
-          [8, 15, 17, 18, 20, 29, 
-           # 30,    # See FIXME: below
-           32, 35,
-           # 37,
+          [8, 15, 17, 18, 20, 27, 28, 30, 33
+           # 35,
           ],
           'walkoptree_simple lines of ' . __FILE__);
 
 # For testing following if/else in code.
 if (@lines) {
-  ok(1);     # FIXME: This line isn't coming out.
+  ok(1);     # We had a bug in not getting this line number once.
 } else {
   ok(0);
 }


### PR DESCRIPTION
This patch updates the file/line when there have been deleted COP nextstate instructions. 

I suspect down the line one will want a corresponding change to Enbugger to reinstate the deleted COP so that those instructions can be stepped and breakpointed.

See the recent discussion on perl5-porters
